### PR TITLE
Add Dependabot automatic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/workflows/extract.yaml
+++ b/.github/workflows/extract.yaml
@@ -2,8 +2,8 @@ name: Extract Plezy APKs
 
 on:
   schedule:
-    # Run daily at 06:00 UTC
-    - cron: "0 6 * * *"
+    # Run hourly at xx:42
+    - cron: "42 * * * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/extract.yaml
+++ b/.github/workflows/extract.yaml
@@ -26,7 +26,7 @@ jobs:
           TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
           BODY=$(echo "$RELEASE_JSON" | jq -r '.body')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          
+
           # Save release body for later
           echo "$BODY" > /tmp/release_body.md
 
@@ -50,48 +50,29 @@ jobs:
         run: |
           TAG="${{ steps.plezy.outputs.tag }}"
           RELEASE_JSON=$(gh api repos/edde746/plezy/releases/tags/$TAG)
-          
+
           mkdir -p apks
-          
-          ARCHS=("arm64-v8a" "armeabi-v7a" "x86_64")
-          
-          for ARCH in "${ARCHS[@]}"; do
+
+          for ARCH in arm64-v8a armeabi-v7a x86_64; do
             ASSET_NAME="plezy-android-${ARCH}.tar.gz"
-            
-            # Get the download URL for this asset
             DOWNLOAD_URL=$(echo "$RELEASE_JSON" | jq -r \
               --arg name "$ASSET_NAME" \
               '.assets[] | select(.name == $name) | .browser_download_url')
-            
+
             if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
               echo "::warning::Asset $ASSET_NAME not found in release $TAG, skipping."
               continue
             fi
-            
+
             echo "Downloading $ASSET_NAME..."
             curl -fsSL -o "/tmp/${ASSET_NAME}" "$DOWNLOAD_URL"
-            
-            echo "Extracting APK from $ASSET_NAME..."
-            tar -xzf "/tmp/${ASSET_NAME}" -C /tmp/
-            
-            # Find the extracted APK and rename it
-            APK_FILE=$(find /tmp -maxdepth 1 -name "*.apk" -newer "/tmp/${ASSET_NAME}" -o -name "*.apk" -newer /tmp/ 2>/dev/null | head -1)
-            
-            # Fallback: look for any apk extracted from the tar
-            if [ -z "$APK_FILE" ]; then
-              APK_FILE=$(find /tmp -maxdepth 2 -name "*.apk" | grep -i "$ARCH\|plezy" | head -1)
-            fi
-            
-            # Second fallback: just list what was extracted
-            if [ -z "$APK_FILE" ]; then
-              echo "Listing tar contents:"
-              tar -tzf "/tmp/${ASSET_NAME}"
-              # Try extracting to a dedicated directory
-              mkdir -p /tmp/extract-${ARCH}
-              tar -xzf "/tmp/${ASSET_NAME}" -C /tmp/extract-${ARCH}/
-              APK_FILE=$(find /tmp/extract-${ARCH} -name "*.apk" | head -1)
-            fi
-            
+
+            EXTRACT_DIR="/tmp/extract-${ARCH}"
+            mkdir -p "$EXTRACT_DIR"
+            tar -xzf "/tmp/${ASSET_NAME}" -C "$EXTRACT_DIR/"
+
+            APK_FILE=$(find "$EXTRACT_DIR" -name "*.apk" | head -1)
+
             if [ -n "$APK_FILE" ]; then
               cp "$APK_FILE" "apks/plezy-android-${ARCH}.apk"
               echo "✅ Extracted: plezy-android-${ARCH}.apk"
@@ -101,23 +82,23 @@ jobs:
               tar -tzf "/tmp/${ASSET_NAME}"
             fi
           done
-          
+
           echo "--- Extracted APKs ---"
           ls -lh apks/
 
-      - name: Create release with APKs
+      - name: Create GitHub release with APKs
         if: steps.check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.plezy.outputs.tag }}"
-          
+
           APK_COUNT=$(find apks -name "*.apk" | wc -l)
           if [ "$APK_COUNT" -eq 0 ]; then
             echo "::error::No APKs extracted, aborting release creation."
             exit 1
           fi
-          
+
           # Build release notes
           {
             echo "## Plezy $TAG — Standalone APKs"
@@ -136,10 +117,10 @@ jobs:
             echo "### Upstream Release Notes"
             cat /tmp/release_body.md
           } > /tmp/notes.md
-          
+
           gh release create "$TAG" \
             --title "Plezy $TAG" \
             --notes-file /tmp/notes.md \
             apks/*.apk
-          
+
           echo "✅ Release $TAG created with $APK_COUNT APK(s)."

--- a/.github/workflows/extract.yaml
+++ b/.github/workflows/extract.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest Plezy release
         id: plezy

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -95,4 +95,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -64,7 +64,7 @@ jobs:
           KEYDNAME: ${{ secrets.KEYDNAME }}
         run: |
           {
-            echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo\""
+            echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks\""
             echo "repo_name: \"Plezy APKs\""
             echo "repo_description: \"Standalone Plezy APKs extracted from upstream releases.\""
             echo "repo_keyalias: \"$REPO_KEYALIAS\""

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -64,7 +64,7 @@ jobs:
           KEYDNAME: ${{ secrets.KEYDNAME }}
         run: |
           {
-            echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks\""
+            echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo\""
             echo "repo_name: \"Plezy APKs\""
             echo "repo_description: \"Standalone Plezy APKs extracted from upstream releases.\""
             echo "repo_keyalias: \"$REPO_KEYALIAS\""
@@ -83,10 +83,15 @@ jobs:
         if: always()
         run: rm -f fdroid/keystore.p12 fdroid/config.yml
 
+      - name: Prepare Pages structure
+        run: |
+          mkdir -p _site/fdroid
+          cp -r fdroid/repo _site/fdroid/repo
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: fdroid/repo
+          path: _site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -89,7 +89,7 @@ jobs:
           cp -r fdroid/repo _site/fdroid/repo
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -49,6 +49,9 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 -d > fdroid/keystore.p12
 
+      - name: Install fdroidserver
+        run: uv tool install fdroidserver
+
       - name: Write fdroid config
         env:
           REPO_KEYALIAS: ${{ secrets.REPO_KEYALIAS }}
@@ -65,14 +68,11 @@ jobs:
             echo "keydname: \"$KEYDNAME\""
             echo "keystore: \"keystore.p12\""
           } > fdroid/config.yml
+          chmod 0600 fdroid/config.yml
 
       - name: Run fdroid update
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}/fdroid:/repo" \
-            -w /repo \
-            registry.gitlab.com/fdroid/docker-executable-fdroidserver:latest \
-            update --verbose
+        working-directory: ${{ github.workspace }}/fdroid
+        run: fdroid update --verbose
 
       - name: Clean up secrets
         if: always()

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           {
             echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo\""
-            echo "repo_name: \"Plezy APKs\""
+            echo "repo_name: \"bl4ckswordsman/plezy-apks\""
             echo "repo_description: \"Standalone Plezy APKs extracted from upstream releases.\""
             echo "repo_keyalias: \"$REPO_KEYALIAS\""
             echo "keystorepass: \"$KEYPASS\""

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
 
       - name: Install fdroidserver
         run: uv tool install fdroidserver

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -1,0 +1,88 @@
+name: Update F-Droid Repo
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  update-fdroid-repo:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Resolve release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          fi
+          echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Download APKs from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p fdroid/repo
+          gh release download "$RELEASE_TAG" --pattern "*.apk" --dir fdroid/repo/
+          echo "APKs downloaded:"
+          ls -lh fdroid/repo/
+
+      - name: Restore keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > fdroid/keystore.p12
+
+      - name: Write fdroid config
+        env:
+          REPO_KEYALIAS: ${{ secrets.REPO_KEYALIAS }}
+          KEYPASS: ${{ secrets.KEYPASS }}
+          KEYDNAME: ${{ secrets.KEYDNAME }}
+        run: |
+          {
+            echo "repo_url: \"https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo\""
+            echo "repo_name: \"Plezy APKs\""
+            echo "repo_description: \"Standalone Plezy APKs extracted from upstream releases.\""
+            echo "repo_keyalias: \"$REPO_KEYALIAS\""
+            echo "keystorepass: \"$KEYPASS\""
+            echo "keypass: \"$KEYPASS\""
+            echo "keydname: \"$KEYDNAME\""
+            echo "keystore: \"keystore.p12\""
+          } > fdroid/config.yml
+
+      - name: Run fdroid update
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/fdroid:/repo" \
+            -w /repo \
+            registry.gitlab.com/fdroid/docker-executable-fdroidserver:latest \
+            fdroid update --create-metadata --verbose
+
+      - name: Clean up secrets
+        if: always()
+        run: rm -f fdroid/keystore.p12 fdroid/config.yml
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: fdroid/repo
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -49,6 +49,9 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 -d > fdroid/keystore.p12
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Install fdroidserver
         run: uv tool install fdroidserver
 

--- a/.github/workflows/fdroid.yaml
+++ b/.github/workflows/fdroid.yaml
@@ -72,7 +72,7 @@ jobs:
             -v "${{ github.workspace }}/fdroid:/repo" \
             -w /repo \
             registry.gitlab.com/fdroid/docker-executable-fdroidserver:latest \
-            fdroid update --create-metadata --verbose
+            update --verbose
 
       - name: Clean up secrets
         if: always()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/)** 
 Add this URL in F-Droid or a compatible client (e.g. [Droid-ify](https://github.com/Droid-ify/client)):
 
 ```
-https://bl4ckswordsman.github.io/plezy-apks
+https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo
 ```
 
 1. Open F-Droid (or Droid-ify)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/)** 
 Add this URL in F-Droid or a compatible client (e.g. [Droid-ify](https://github.com/Droid-ify/client)):
 
 ```
-https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo
+https://bl4ckswordsman.github.io/plezy-apks
 ```
 
 1. Open F-Droid (or Droid-ify)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
 
 ## Install via F-Droid
 
-[![Add to F-Droid](https://img.shields.io/badge/F--Droid-Add%20Repo-1976D2?logo=fdroid)](https://bl4ckswordsman.github.io/plezy-apks/)
+[![Add to F-Droid](https://img.shields.io/badge/F--Droid-Add%20Repo-1976D2?logo=fdroid)](https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo)
 
-Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
+Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
 
 <details>
 <summary><strong>Manual setup</strong></summary>

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
 
 ## Install via F-Droid
 
-Add the custom repo in F-Droid or a compatible client (e.g. [Droid-ify](https://github.com/Droid-ify/client)):
+Visit the **[F-Droid repo landing page](https://bl4ckswordsman.github.io/plezy-apks/)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
+
+<details>
+<summary><strong>Manual setup</strong></summary>
+
+Add this URL in F-Droid or a compatible client (e.g. [Droid-ify](https://github.com/Droid-ify/client)):
 
 ```
 https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo
 ```
-
-<details>
-<summary><strong>Expand Instructions</strong></summary>
 
 1. Open F-Droid (or Droid-ify)
 2. Go to **Settings → Repositories → Add repository**
@@ -74,7 +76,7 @@ Since Plezy v1.13.0, Android builds are packaged as `.tar.gz` archives. This bre
 **F-Droid repo** — triggers on each new release:
 1. Downloads the APKs from the new GitHub release
 2. Runs `fdroid update` to regenerate the signed index
-3. Deploys the index + APKs to GitHub Pages
+3. Deploys the index + APKs to GitHub Pages (no binaries committed to git)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 # Plezy APK Releases
 
 [![Extract Plezy APKs](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml)
+[![Update F-Droid Repo](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yml)
 
-Standalone `.apk` files automatically extracted from [edde746/plezy](https://github.com/edde746/plezy) releases — ready to install or use with [Obtainium](https://github.com/ImranR98/Obtainium).
+Standalone `.apk` files automatically extracted from [edde746/plezy](https://github.com/edde746/plezy) releases — ready to install via F-Droid, Obtainium, or direct download.
+
+## Install via F-Droid
+
+Add the custom repo in F-Droid or a compatible client (e.g. [Droid-ify](https://github.com/Droid-ify/client)):
+
+```
+https://bl4ckswordsman.github.io/plezy-apks/fdroid/repo
+```
+
+<details>
+<summary><strong>Expand Instructions</strong></summary>
+
+1. Open F-Droid (or Droid-ify)
+2. Go to **Settings → Repositories → Add repository**
+3. Paste the URL above
+4. Search for **Plezy** and install
+
+</details>
 
 ## Install via Obtainium
+
 [![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/bl4ckswordsman/plezy-apks/releases)
 
-### Manual Obtainium Steps
 <details>
 <summary><strong>Expand Instructions</strong></summary>
 
@@ -41,19 +60,25 @@ Head to the [Releases](https://github.com/bl4ckswordsman/plezy-apks/releases/lat
 <summary><strong>Under the Hood (Why & How)</strong></summary>
 
 ### Why?
-Since Plezy v1.13.0, Android builds are packaged as `.tar.gz` archives. This breaks Obtainium auto-updates and makes manual installation inconvenient. This repo automatically extracts the APKs daily and publishes them as proper GitHub releases.
+Since Plezy v1.13.0, Android builds are packaged as `.tar.gz` archives. This breaks Obtainium auto-updates and makes manual installation inconvenient. This repo automatically extracts the APKs daily and publishes them as proper GitHub releases, and also maintains an F-Droid-compatible repo served via GitHub Pages.
 
 ### How it works
-A GitHub Action runs daily and on-demand:
+
+**APK extraction** — runs daily and on-demand:
 1. Checks the latest [Plezy release](https://github.com/edde746/plezy/releases)
 2. Skips if the version is already published here
 3. Downloads all Android `.tar.gz` archives
 4. Extracts the `.apk` files
-5. Creates a new release with standalone APKs + upstream changelog
+5. Creates a new GitHub release with standalone APKs + upstream changelog
+
+**F-Droid repo** — triggers on each new release:
+1. Downloads the APKs from the new GitHub release
+2. Runs `fdroid update` to regenerate the signed index
+3. Deploys the index + APKs to GitHub Pages
 
 ---
 
 ### Run It Yourself
-Want to run this yourself? Fork this repo or copy `.github/workflows/extract-apk.yml` into a new repo. No configuration needed — it works out of the box with the default `GITHUB_TOKEN`.
+Fork this repo or copy `.github/workflows/` into a new repo. The extract workflow needs no configuration — it works out of the box with the default `GITHUB_TOKEN`. The F-Droid workflow additionally requires these repository secrets: `KEYSTORE_BASE64`, `REPO_KEYALIAS`, `KEYPASS`, `KEYDNAME`.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
 
 ## Install via F-Droid
 
+[![Add to F-Droid](https://img.shields.io/badge/F--Droid-Add%20Repo-1976D2?logo=fdroid)](https://bl4ckswordsman.github.io/plezy-apks/)
+
 Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plezy APK Releases
 
-[![Extract Plezy APKs](https://github.com/derFrisson/plezy-apks/actions/workflows/extract.yaml/badge.svg)](https://github.com/derFrisson/plezy-apks/actions/workflows/extract.yaml)
+[![Extract Plezy APKs](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml)
 
 Standalone `.apk` files automatically extracted from [edde746/plezy](https://github.com/edde746/plezy) releases — ready to install or use with [Obtainium](https://github.com/ImranR98/Obtainium).
 
@@ -10,7 +10,7 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
 2. Tap **Add App**
 3. Paste this URL:
    ```
-   https://github.com/derFrisson/plezy-apks
+   https://github.com/bl4ckswordsman/plezy-apks
    ```
 4. Set **APK filter regex** to match your device:
    - `arm64-v8a` — most modern phones *(recommended)*
@@ -20,7 +20,7 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
 
 ## Direct Download
 
-Head to the [Releases](https://github.com/derFrisson/plezy-apks/releases/latest) page and grab the APK for your architecture.
+Head to the [Releases](https://github.com/bl4ckswordsman/plezy-apks/releases/latest) page and grab the APK for your architecture.
 
 | File | Architecture | Devices |
 |------|-------------|---------|
@@ -45,6 +45,6 @@ A GitHub Action runs daily and on-demand:
 
 ---
 
-### Self-hosting
+### Run It Yourself
 
 Want to run this yourself? Fork this repo or copy `.github/workflows/extract-apk.yml` into a new repo. No configuration needed — it works out of the box with the default `GITHUB_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 Standalone `.apk` files automatically extracted from [edde746/plezy](https://github.com/edde746/plezy) releases — ready to install or use with [Obtainium](https://github.com/ImranR98/Obtainium).
 
 ## Install via Obtainium
+[![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/bl4ckswordsman/plezy-apks/releases)
+
+### Manual Obtainium Steps
+<details>
+<summary><strong>Expand Instructions</strong></summary>
 
 1. Open Obtainium
 2. Tap **Add App**
@@ -17,6 +22,8 @@ Standalone `.apk` files automatically extracted from [edde746/plezy](https://git
    - `armeabi-v7a` — older 32-bit devices
    - `x86_64` — emulators / ChromeOS
 5. Done — Obtainium will auto-update Plezy for you
+
+</details>
 
 ## Direct Download
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ Head to the [Releases](https://github.com/bl4ckswordsman/plezy-apks/releases/lat
 
 > **Not sure which one?** Almost all modern Android phones use `arm64-v8a`.
 
-## Why?
+<details>
+<summary><strong>Under the Hood (Why & How)</strong></summary>
 
+### Why?
 Since Plezy v1.13.0, Android builds are packaged as `.tar.gz` archives. This breaks Obtainium auto-updates and makes manual installation inconvenient. This repo automatically extracts the APKs daily and publishes them as proper GitHub releases.
 
-## How it works
-
+### How it works
 A GitHub Action runs daily and on-demand:
 1. Checks the latest [Plezy release](https://github.com/edde746/plezy/releases)
 2. Skips if the version is already published here
@@ -46,5 +47,6 @@ A GitHub Action runs daily and on-demand:
 ---
 
 ### Run It Yourself
-
 Want to run this yourself? Fork this repo or copy `.github/workflows/extract-apk.yml` into a new repo. No configuration needed — it works out of the box with the default `GITHUB_TOKEN`.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Plezy APK Releases
 
 [![Extract Plezy APKs](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/extract.yaml)
-[![Update F-Droid Repo](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yml)
+[![Update F-Droid Repo](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yaml/badge.svg)](https://github.com/bl4ckswordsman/plezy-apks/actions/workflows/fdroid.yaml)
 
 Standalone `.apk` files automatically extracted from [edde746/plezy](https://github.com/edde746/plezy) releases — ready to install via F-Droid, Obtainium, or direct download.
 
 ## Install via F-Droid
 
-Visit the **[F-Droid repo landing page](https://bl4ckswordsman.github.io/plezy-apks/)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
+Visit the **[F-Droid repo page](https://bl4ckswordsman.github.io/plezy-apks/)** — tap the link to add the repo directly in your F-Droid client, or scan the QR code.
 
 <details>
 <summary><strong>Manual setup</strong></summary>

--- a/fdroid/metadata/com.edde746.plezy.yml
+++ b/fdroid/metadata/com.edde746.plezy.yml
@@ -1,0 +1,18 @@
+Categories:
+  - Multimedia
+AuthorName: edde746
+Name: Plezy
+Summary: Modern cross-platform Plex client built with Flutter
+Description: |
+  A modern Plex client for desktop and mobile.
+  Built with Flutter for native performance and a clean interface.
+
+  Republished standalone APKs for Obtainium and F-Droid use.
+
+License: GPL-3.0-only
+SourceCode: https://github.com/edde746/plezy
+IssueTracker: https://github.com/edde746/plezy/issues
+Changelog: https://github.com/edde746/plezy/releases
+
+AutoUpdateMode: None
+UpdateCheckMode: None


### PR DESCRIPTION
Add GitHub Dependabot to keep the GitHub Actions packages up-to-date.
Currently configured for weekly updates.